### PR TITLE
address feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ and linked to them in the codebase at their approximate locations.
 
 Edit: more questions...
 - What should we do if the client ID of a Chargeback, Resolve or Dispute does not match the client ID of the original 
-  record? Error? (Not handled.)
+  record? Error? (We print an error and do not process it.)
 - What should we do if a Chargeback or Resolve does not have a corresponding Dispute? (Not handled.)
 
 > For the cases you are handling are you handling them correctly?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,10 @@ fn process_record(
                 "Disputed record tx {} could not be found",
                 record.tx
             ))?;
+            ensure!(
+                disputed_record.client == record.client,
+                "Disputed record and current record have different client IDs"
+            );
             client.available -= disputed_record.amount;
             client.held += disputed_record.amount;
         }
@@ -216,6 +220,10 @@ fn process_record(
                 "Resolved record tx {} could not be found",
                 record.tx
             ))?;
+            ensure!(
+                resolved_record.client == record.client,
+                "Resolved record and current record have different client IDs"
+            );
             // TODO - what happens if held is less than resolved amount?
             client.available += resolved_record.amount;
             client.held -= resolved_record.amount;
@@ -225,6 +233,10 @@ fn process_record(
                 "Chargeback record tx {} could not be found",
                 record.tx
             ))?;
+            ensure!(
+                chargeback_record.client == record.client,
+                "Chargeback record and current record have different client IDs"
+            );
             // TODO - what happens if available/held are less than chargeback amount?
             client.total -= chargeback_record.amount;
             client.held -= chargeback_record.amount;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,13 @@ fn process_record(
     let mut client = *clients
         .entry(record.client)
         .or_insert_with(|| Client::new(record.client));
-    // TODO - what if it is frozen? https://github.com/webern/moneybags/issues/4
+
+    // TODO - what if it is locked? https://github.com/webern/moneybags/issues/4
+    // In the absence of guidance on locked accounts, we will assume that we
+    // should not process records for accounts that are locked. Note that there
+    // is no way for an account to become unlocked.
+    ensure!(!client.locked, "Client account is locked");
+
     match record.record_type {
         RecordType::Deposit => {
             client.available += record.amount;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use serde_plain::{derive_display_from_serialize, derive_fromstr_from_deserialize
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 /// Processes the transactions found in <CSV_FILE> and outputs a CSV to stdout summarizing the
@@ -30,9 +30,11 @@ impl Moneybags {
     /// Writes a csv-formatted summary of the accounts found in `self.csv_file`. By taking a `Write`
     /// instead of writing to `stdout`, we make the program easier to test.
     pub fn run(&self, writer: impl Write) -> Result<()> {
-        let records = Records::from_file(&self.csv_file)
-            .context(format!("Unable to open file '{}'", self.csv_file.display()))?;
-        let clients = process_records(&records)?;
+        let f = BufReader::new(
+            File::open(&self.csv_file)
+                .context(format!("Unable to open file '{}'", self.csv_file.display()))?,
+        );
+        let clients = process_records(f)?;
         let mut csv_writer = WriterBuilder::new().has_headers(true).from_writer(writer);
         for client in clients {
             csv_writer.serialize(client)?;
@@ -118,55 +120,6 @@ where
     Ok(parsed)
 }
 
-/// A wrapping type for a collection of records.
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct Records(BTreeMap<Id, Record>);
-
-/// Dispute, Resolve and Chargeback records do not have an IDs of there own, but I want to give them
-/// some unique ID so they can be stored in the same map as Deposit and Withdrawal transactions.
-// TODO - this is hacky, see https://github.com/webern/moneybags/issues/2
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Hash)]
-enum Id {
-    /// A Deposit or Withdrawal that has a real ID.
-    Tx(u32),
-    /// A Dispute, Resolve or Chargeback for which we have not been given a real ID. We make one up
-    /// instead.
-    Fake(u32),
-}
-
-impl Records {
-    /// Parse the CSV data in a `reader`.
-    pub fn from_reader(reader: impl Read) -> Result<Self> {
-        let mut csv_reader = csv::Reader::from_reader(reader);
-        let mut records = BTreeMap::new();
-        let mut fake_id = 0u32;
-
-        for result in csv_reader.deserialize() {
-            let record: Record = result?;
-            // HACK - Dispute, Resolve and Chargeback records do not have a transaction ID. We want
-            // to keep them in a map along with the Deposit and Withdrawal transactions that do have
-            // IDs so we create a synthetic "fake" ID for the transactions that do not have one.
-            let id = match record.record_type {
-                RecordType::Deposit | RecordType::Withdrawal => Id::Tx(record.tx),
-                RecordType::Dispute | RecordType::Resolve | RecordType::Chargeback => {
-                    fake_id += 1;
-                    Id::Fake(fake_id)
-                }
-            };
-            records.insert(id, record);
-        }
-
-        Ok(Self(records))
-    }
-
-    /// Parse the CSV data from a file.
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        let f = File::open(path.as_ref())?;
-        let br = BufReader::new(f);
-        Self::from_reader(br)
-    }
-}
-
 /// Represents the status of a client/account.
 #[derive(
     Debug, Default, Clone, Copy, Eq, Ord, PartialEq, PartialOrd, Hash, Serialize, Deserialize,
@@ -190,217 +143,91 @@ impl Client {
     }
 }
 
-fn process_records(records: &Records) -> Result<Vec<Client>> {
+fn process_records(reader: impl Read) -> Result<Vec<Client>> {
+    let mut csv_reader = csv::Reader::from_reader(reader);
+    let mut records = BTreeMap::new();
     let mut clients = BTreeMap::new();
-    for record in records.0.values() {
-        // We take a copy of the `Client` and overwrite it later to ensure atomicity.
-        let mut client = *clients
-            .entry(record.client)
-            .or_insert_with(|| Client::new(record.client));
-        // TODO - what if it is frozen? https://github.com/webern/moneybags/issues/4
-        match record.record_type {
-            RecordType::Deposit => {
-                client.available += record.amount;
-                client.total += record.amount;
+
+    for result in csv_reader.deserialize() {
+        let record: Record = match result {
+            Ok(ok) => ok,
+            Err(e) => {
+                eprintln!("Error parsing csv line: {}", e);
+                continue;
             }
-            RecordType::Withdrawal => {
-                ensure!(
-                    client.available >= record.amount,
-                    "Withdrawal failed. Available funds insufficient."
-                );
-                client.available -= record.amount;
-                client.total -= record.amount;
-            }
-            RecordType::Dispute => {
-                let disputed_record = records.0.get(&Id::Tx(record.tx)).context(format!(
-                    "Disputed record tx {} could not be found",
-                    record.tx
-                ))?;
-                client.available -= disputed_record.amount;
-                client.held += disputed_record.amount;
-            }
-            RecordType::Resolve => {
-                let resolved_record = records.0.get(&Id::Tx(record.tx)).context(format!(
-                    "Resolved record tx {} could not be found",
-                    record.tx
-                ))?;
-                // TODO - what happens if held is less than resolved amount?
-                client.available += resolved_record.amount;
-                client.held -= resolved_record.amount;
-            }
-            RecordType::Chargeback => {
-                let chargeback_record = records.0.get(&Id::Tx(record.tx)).context(format!(
-                    "Chargeback record tx {} could not be found",
-                    record.tx
-                ))?;
-                // TODO - what happens if available/held are less than chargeback amount?
-                client.total -= chargeback_record.amount;
-                client.held -= chargeback_record.amount;
-                client.locked = true;
-            }
+        };
+
+        if let Err(e) = process_record(&record, &records, &mut clients) {
+            eprintln!("Error processing record: {}", e);
         }
 
-        // Atomically update the map with our transaction by copying over the value in the map. If
-        // this were a real system we would need to verify that the data in the database has not
-        // changed since we first accessed it. This can be done with object version numbers or
-        // database transactions. (Watch out for database transactions though!)
-        clients.insert(client.id, client);
+        // We need to store transactions because they may become disputed later. We do not need to
+        // store dispute, resolve or chargeback records because these can not be further referenced.
+        if matches!(
+            record.record_type,
+            RecordType::Deposit | RecordType::Withdrawal
+        ) {
+            records.insert(record.tx, record);
+        }
     }
 
     Ok(clients.into_iter().map(|(_, client)| client).collect())
 }
 
-// Tests ///////////////////////////////////////////////////////////////////////////////////////////
-#[cfg(test)]
-mod test {
-    use super::*;
-    use maplit::btreemap;
-
-    const DATA: &str = r#"type,client,tx,amount
-deposit,1,1,1.0111
-"withdrawal",2,22,2.0222
-dispute,"33",3,
-resolve,4,44,
-chargeback,555,"55","#;
-
-    #[test]
-    fn input_parsing() {
-        let records = Records::from_reader(DATA.as_bytes()).unwrap();
-
-        assert_eq!(
-            *records.0.get(&Id::Tx(1)).unwrap(),
-            Record {
-                record_type: RecordType::Deposit,
-                client: 1,
-                tx: 1,
-                amount: Decimal::new(10111, 4),
-            }
-        );
-
-        assert_eq!(
-            *records.0.get(&Id::Tx(22)).unwrap(),
-            Record {
-                record_type: RecordType::Withdrawal,
-                client: 2,
-                tx: 22,
-                amount: Decimal::new(20222, 4),
-            }
-        );
-
-        assert_eq!(
-            *records.0.get(&Id::Fake(1)).unwrap(),
-            Record {
-                record_type: RecordType::Dispute,
-                client: 33,
-                tx: 3,
-                amount: Default::default(),
-            }
-        );
-
-        assert_eq!(
-            *records.0.get(&Id::Fake(2)).unwrap(),
-            Record {
-                record_type: RecordType::Resolve,
-                client: 4,
-                tx: 44,
-                amount: Default::default(),
-            }
-        );
-
-        assert_eq!(
-            *records.0.get(&Id::Fake(3)).unwrap(),
-            Record {
-                record_type: RecordType::Chargeback,
-                client: 555,
-                tx: 55,
-                amount: Default::default(),
-            }
-        );
+fn process_record(
+    record: &Record,
+    records: &BTreeMap<u32, Record>,
+    clients: &mut BTreeMap<u32, Client>,
+) -> Result<()> {
+    // We take a copy of the `Client` and overwrite it later to ensure atomicity.
+    let mut client = *clients
+        .entry(record.client)
+        .or_insert_with(|| Client::new(record.client));
+    // TODO - what if it is frozen? https://github.com/webern/moneybags/issues/4
+    match record.record_type {
+        RecordType::Deposit => {
+            client.available += record.amount;
+            client.total += record.amount;
+        }
+        RecordType::Withdrawal => {
+            ensure!(
+                client.available >= record.amount,
+                "Withdrawal failed. Available funds insufficient."
+            );
+            client.available -= record.amount;
+            client.total -= record.amount;
+        }
+        RecordType::Dispute => {
+            let disputed_record = records.get(&record.tx).context(format!(
+                "Disputed record tx {} could not be found",
+                record.tx
+            ))?;
+            client.available -= disputed_record.amount;
+            client.held += disputed_record.amount;
+        }
+        RecordType::Resolve => {
+            let resolved_record = records.get(&record.tx).context(format!(
+                "Resolved record tx {} could not be found",
+                record.tx
+            ))?;
+            // TODO - what happens if held is less than resolved amount?
+            client.available += resolved_record.amount;
+            client.held -= resolved_record.amount;
+        }
+        RecordType::Chargeback => {
+            let chargeback_record = records.get(&record.tx).context(format!(
+                "Chargeback record tx {} could not be found",
+                record.tx
+            ))?;
+            // TODO - what happens if available/held are less than chargeback amount?
+            client.total -= chargeback_record.amount;
+            client.held -= chargeback_record.amount;
+            client.locked = true;
+        }
     }
 
-    #[test]
-    fn process_resolve() {
-        let records = Records(btreemap![
-          Id::Tx(1) => Record {
-                record_type: RecordType::Deposit,
-                client: 1,
-                tx: 1,
-                amount: Decimal::new(2009999, 4),
-            },
-          Id::Tx(2) => Record {
-                record_type: RecordType::Withdrawal,
-                client: 1,
-                tx: 2,
-                amount: Decimal::new(1005001, 4),
-            },
-          Id::Fake(1) => Record {
-                record_type: RecordType::Dispute,
-                client: 1,
-                tx: 2,
-                ..Default::default()
-            },
-          Id::Fake(2) => Record {
-                record_type: RecordType::Resolve,
-                client: 1,
-                tx: 2,
-                ..Default::default()
-            },
-        ]);
+    // Atomically update the map with our transaction by copying over the value in the map.
+    clients.insert(client.id, client);
 
-        let clients = process_records(&records).unwrap();
-        let client = clients.first().unwrap();
-        assert_eq!(
-            *client,
-            Client {
-                id: 1,
-                // 100.4998
-                available: Decimal::new(1004998, 4),
-                total: Decimal::new(1004998, 4),
-                ..Default::default()
-            }
-        );
-    }
-
-    #[test]
-    fn process_chargeback() {
-        let records = Records(btreemap![
-          Id::Tx(1) => Record {
-                record_type: RecordType::Deposit,
-                client: 1,
-                tx: 1,
-                amount: Decimal::new(2009999, 4),
-            },
-          Id::Tx(2) => Record {
-                record_type: RecordType::Withdrawal,
-                client: 1,
-                tx: 2,
-                amount: Decimal::new(1005001, 4),
-            },
-          Id::Fake(1) => Record {
-                record_type: RecordType::Dispute,
-                client: 1,
-                tx: 1,
-                ..Default::default()
-            },
-          Id::Fake(2) => Record {
-                record_type: RecordType::Chargeback,
-                client: 1,
-                tx: 1,
-                ..Default::default()
-            },
-        ]);
-
-        let clients = process_records(&records).unwrap();
-        let client = clients.first().unwrap();
-        assert_eq!(
-            *client,
-            Client {
-                id: 1,
-                available: Decimal::new(-1005001, 4),
-                total: Decimal::new(-1005001, 4),
-                locked: true,
-                ..Default::default()
-            }
-        );
-    }
+    Ok(())
 }

--- a/tests/integ.rs
+++ b/tests/integ.rs
@@ -43,7 +43,7 @@ fn resolve_and_chargeback() {
     let output = String::from_utf8(output_bytes.into_inner()).unwrap();
     let expected = r#"client,available,held,total,locked
 1,3.4,0.0,3.4,false
-2,1.2999,0.0,1.2999,true
+2,1.4999,0.0,1.4999,true
 "#;
     assert_eq!(output, expected);
 }

--- a/tests/integ.rs
+++ b/tests/integ.rs
@@ -13,11 +13,19 @@ fn path(filename: impl AsRef<str>) -> PathBuf {
 /// made with insufficient funds.
 #[test]
 fn given_example() {
-    assert!(Moneybags {
+    let mut output_bytes = Cursor::new(Vec::<u8>::new());
+    Moneybags {
         csv_file: path("given-example.csv"),
     }
-    .run(Cursor::new(Vec::<u8>::new()))
-    .is_err());
+    .run(&mut output_bytes)
+    .unwrap();
+
+    let output = String::from_utf8(output_bytes.into_inner()).unwrap();
+    let expected = r#"client,available,held,total,locked
+1,1.5,0,1.5,false
+2,2.0,0,2.0,false
+"#;
+    assert_eq!(output, expected);
 }
 
 /// An example containing two clients, one of which has a resolve and the other a chargeback.


### PR DESCRIPTION
Closes #7
Closes #2
Changes behavior of #4 

```
    validate client id

    For dispute, resolve and chargeback records we now validate that the
    client ID is correct.
```

```
    do not process locked accounts

    We have changed our assumption on the unspecified handling of locked
    accounts. Previously we processed a transaction for a locked account,
    now we do not.
```

```
    address feedback

    We no longer stop processing when insufficient funds are encountered.
    We also continue processing if a row of the CSV fails to deserialize.
```